### PR TITLE
Add Japanese docs and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# 250613_codex-test-01
+# Todo CLI
+
+Click を利用したシンプルな TODO 管理ツールです。
+
+## 使い方
+
+```bash
+python todo_cli.py add "Buy milk"
+python todo_cli.py list
+python todo_cli.py done 1
+```
+
+保存ファイルを変更したい場合は `TODO_FILE` 環境変数を設定してください。
+

--- a/tests/test_todo_cli.py
+++ b/tests/test_todo_cli.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import json
+from click.testing import CliRunner
+from todo_cli import cli, read_tasks
+
+
+def test_add_and_list(tmp_path):
+    tasks_file = tmp_path / "tasks.json"
+    env = {"TODO_FILE": str(tasks_file)}
+    runner = CliRunner()
+    result = runner.invoke(cli, ["add", "write tests"], env=env)
+    assert result.exit_code == 0
+    assert "Added task" in result.output
+
+    result = runner.invoke(cli, ["list"], env=env)
+    assert "[ ] write tests" in result.output
+
+    data = json.loads(tasks_file.read_text())
+    assert data["tasks"][0]["description"] == "write tests"
+    assert not data["tasks"][0]["done"]
+
+
+def test_done(tmp_path):
+    tasks_file = tmp_path / "tasks.json"
+    env = {"TODO_FILE": str(tasks_file)}
+    runner = CliRunner()
+    runner.invoke(cli, ["add", "task1"], env=env)
+    result = runner.invoke(cli, ["done", "1"], env=env)
+    assert result.exit_code == 0
+    assert "Marked task 1 as done" in result.output
+
+    tasks = read_tasks(str(tasks_file))
+    assert tasks[0]["done"] is True

--- a/todo_cli.py
+++ b/todo_cli.py
@@ -1,0 +1,69 @@
+import json
+import os
+import click
+
+
+def default_file():
+    return os.environ.get('TODO_FILE', 'tasks.json')
+
+
+def read_tasks(file_path=None):
+    file_path = file_path or default_file()
+    if not os.path.exists(file_path):
+        return []
+    with open(file_path, 'r') as f:
+        try:
+            data = json.load(f)
+            return data.get('tasks', [])
+        except json.JSONDecodeError:
+            return []
+
+
+def write_tasks(tasks, file_path=None):
+    file_path = file_path or default_file()
+    with open(file_path, 'w') as f:
+        json.dump({'tasks': tasks}, f)
+
+
+@click.group()
+def cli():
+    """シンプルなTODO CLI。"""
+    pass
+
+
+@cli.command()
+@click.argument('description')
+def add(description):
+    """新しいタスクを追加します。"""
+    tasks = read_tasks()
+    next_id = max([t['id'] for t in tasks], default=0) + 1
+    tasks.append({'id': next_id, 'description': description, 'done': False})
+    write_tasks(tasks)
+    click.echo(f"Added task {next_id}: {description}")
+
+
+@cli.command(name='list')
+def list_tasks():
+    """すべてのタスクを表示します。"""
+    tasks = read_tasks()
+    for t in tasks:
+        status = 'x' if t.get('done') else ' '
+        click.echo(f"{t['id']}. [{status}] {t['description']}")
+
+
+@cli.command()
+@click.argument('task_id', type=int)
+def done(task_id):
+    """指定したタスクを完了済みにします。"""
+    tasks = read_tasks()
+    for t in tasks:
+        if t['id'] == task_id:
+            t['done'] = True
+            write_tasks(tasks)
+            click.echo(f"Marked task {task_id} as done")
+            return
+    click.echo(f"Task {task_id} not found", err=True)
+
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
## Summary
- READMEを日本語化
- todo_cli.pyのdocstringを日本語化

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bbdd8a44c8331b75b2da49790dc21